### PR TITLE
fix: skip edge on linux-arm64

### DIFF
--- a/platforms/utility/apply-browser-launcher-karma-config.js
+++ b/platforms/utility/apply-browser-launcher-karma-config.js
@@ -21,11 +21,19 @@ function applyBrowserLauncherKarmaConfig(config, browserSetName) {
     name: 'WebkitHeadless',
   });
 
-  const browserSets = {
+  let browserSets = {
     speedy: ['chrome'],
     quirky: ['chrome', 'edge'],
     paranoid: ['chrome', 'edge', 'firefox', 'safari'],
   };
+  if (process.arch === 'arm64' && process.platform === 'linux') {
+    // Edge is not available on Linux ARM64
+    browserSets = {
+      speedy: ['chrome'],
+      quirky: ['chrome'],
+      paranoid: ['chrome', 'firefox', 'safari'],
+    };
+  }
 
   const browserSet = browserSets[browserSetName];
   if (browserSet) {


### PR DESCRIPTION
Edge does not currently support Linux on ARM64.