### PR TITLE
Enable `clearContext` in the karma configuration

### DIFF
--- a/platforms/shared/karma/karma.angular-cli.conf.js
+++ b/platforms/shared/karma/karma.angular-cli.conf.js
@@ -21,7 +21,7 @@ module.exports = function (config) {
         // or set a specific seed with `seed: 4321`
         random: false,
       },
-      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+      clearContext: true, // we do not have the HTML reporter configured, so there is no need to retain context in the browser
     },
     coverageReporter: {
       dir: require('path').join(process.cwd(), './coverage'), // Angular sets this to './coverage/project-name' by default.


### PR DESCRIPTION
AB#4029642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser test-runner behavior by clearing the Jasmine spec runner context between runs, helping prevent leftover test output from affecting subsequent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->