### PR TITLE
Disable shared memory

### DIFF
--- a/platforms/shared/karma/karma.angular-cli.conf.js
+++ b/platforms/shared/karma/karma.angular-cli.conf.js
@@ -41,6 +41,7 @@ module.exports = function (config) {
           '--disable-extensions',
           '--disable-gpu',
           '--no-sandbox',
+          '--disable-dev-shm-usage',
           '--window-size=1920,1080',
         ],
       },


### PR DESCRIPTION
Use `/tmp` instead of `/dev/shm` for temp files.